### PR TITLE
qp-band dimension change and visualize_correlated_state method change

### DIFF
--- a/westpy/qdet/json_parser.py
+++ b/westpy/qdet/json_parser.py
@@ -20,6 +20,23 @@ def read_parameters(filename: str):
 
     return nspin, npair, bands
 
+def read_lband(bands):
+    """Determine the numbers of band
+
+    Argument:
+    bands: the bands returned from read_parameters()
+    """
+    #length of bands list: lband
+    if isinstance(bands[0],np.ndarray) and len(bands)==2: 
+        #print("Band is spin resolved")
+        if len(bands[0])==len(bands[1]):
+            lband = len(bands[0])
+        else:
+            raise NotImplementedError("Different N.O orbitals from two channel case is not implemented!")
+    else:
+        lband = len(bands)
+    return lband
+
 
 def read_qp_energies(filename: str):
     """Read QP energies from JSON file.
@@ -37,7 +54,7 @@ def read_qp_energies(filename: str):
         qp_energies = np.array(raw_["output"]["Q"]["K000001"]["eqpSec"])
 
     elif nspin == 2:
-        qp_energies = np.zeros((len(bands), 2))
+        qp_energies = np.zeros((read_lband(bands), 2))
         qp_energies[:, 0] = np.array(raw_["output"]["Q"]["K000001"]["eqpSec"])
         qp_energies[:, 1] = np.array(raw_["output"]["Q"]["K000002"]["eqpSec"])
 
@@ -55,7 +72,7 @@ def read_occupation(filename: str):
 
     nspin, npair, bands = read_parameters(filename)
 
-    occ_ = np.zeros((nspin, len(bands)))
+    occ_ = np.zeros((nspin, read_lband(bands)))
 
     for ispin in range(nspin):
         string1 = "K" + format(ispin + 1, "06d")
@@ -103,7 +120,8 @@ def read_matrix_elements(filename: str, string: str = "eri_w"):
                 )
 
     # unfold one-body terms from pair basis to Kohn-Sham basis
-    h1e = np.zeros((nspin, len(bands), len(bands)))
+
+    h1e = np.zeros((nspin, read_lband(bands), read_lband(bands)))
     for ispin in range(nspin):
         for ipair in range(len(indexmap)):
             i, j = indexmap[ipair]
@@ -115,10 +133,10 @@ def read_matrix_elements(filename: str, string: str = "eri_w"):
         (
             nspin,
             nspin,
-            len(bands),
-            len(bands),
-            len(bands),
-            len(bands),
+            read_lband(bands),
+            read_lband(bands),
+            read_lband(bands),
+            read_lband(bands),
         )
     )
     for ispin in range(nspin):

--- a/westpy/qdet/misc.py
+++ b/westpy/qdet/misc.py
@@ -14,11 +14,24 @@ def visualize_correlated_state(evcs, norb, nelec, cutoff=10 ** (-3)):
     """
     # constrcut N-particle Fock space
     string_fock = []
-    for i in range(2):
-        determinants = cistring.make_strings(range(norb), nelec[i])
-        string_fock.append(
-            ["|" + format(entry, "0" + str(norb) + "b") + ">" for entry in determinants]
-        )
+    if norb<=64:
+        for i in range(2):
+            determinants = cistring.make_strings(range(norb), nelec[i])
+            string_fock.append(
+                ["|" + format(entry, "0" + str(norb) + "b") + ">" for entry in determinants]
+            )
+    else: #if the orbital>64. pyscf have different implementation 
+        for i in range(2):
+            determinants = cistring.gen_occslst(range(norb), nelec[i])
+            string_one_fock = []
+            for entry in determinants:
+                #generate the binary string as <64 case.
+                string_occ=['0']*norb
+                for i in entry:
+                    string_occ[i]='1'
+                string_occ=''.join(reversed(string_occ))
+                string_one_fock.append("|" + string_occ + ">")
+            string_fock.append(string_one_fock)
 
     # string for many-body state
     string = ""


### PR DESCRIPTION
Two changes: 
1. replace len(band) with a function that can give right number of bands when qp_bands=[..]  or qp_bands=[[..],[..]]

3. updated the slater determinant visualization method to accommodate the pyscf 2.4 version's different implementation on cistring when norb>64