### PR TITLE
Fix error when empty lines are present before "ATOMIC_POSITIONS" in pw.in input file

### DIFF
--- a/westpy/relaxation.py
+++ b/westpy/relaxation.py
@@ -493,7 +493,7 @@ class bfgs_iter:
 
         for start, line in enumerate(lines):
             if line:
-                if line.split()[0] == "ATOMIC_POSITIONS":
+                if line.split() and line.split()[0] == "ATOMIC_POSITIONS":
                     break
 
         # update atomic positions
@@ -518,7 +518,7 @@ class bfgs_iter:
 
             for start, line in enumerate(lines):
                 if line:
-                    if line.split()[0] == "ATOMIC_POSITIONS":
+                    if line.split() and line.split()[0] == "ATOMIC_POSITIONS":
                         break
 
             # update atomic positions


### PR DESCRIPTION
**Description:**  
This pull request adds a condition to handle empty lines when parsing the `pw.in` input file. Specifically, the code now checks if a line is not empty before attempting to access its first element, preventing an error when empty lines are encountered before the "ATOMIC_POSITIONS" section.  
The updated condition is:  
```python
if line.split() and line.split()[0] == "ATOMIC_POSITIONS":
```
This ensures that the script processes "ATOMIC_POSITIONS" correctly even if there are blank lines in the input, improving robustness and preventing potential crashes during parsing.